### PR TITLE
Fixes tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:node": "wasm-pack build --target nodejs --out-dir pkg-node",
     "build:web": "wasm-pack build --target web --out-dir pkg-web",
     "build:all": "npm run build && npm run build:node && npm run build:web",
-    "test": "npm run build && node test-serve.mjs",
+    "test": "npm run build:web && node test-serve.mjs",
     "test:node": "npm run build:node && node test-node.mjs"
   },
   "keywords": [

--- a/test-node.mjs
+++ b/test-node.mjs
@@ -15,7 +15,7 @@ async function testVerification() {
     console.log('✅ WASM module initialized\n');
 
     // Load eth block proof and verification key
-    const kbProofPath = path.join(__dirname, 'proofs', 'zisk.proof.ethproofs.bin');
+    const kbProofPath = path.join(__dirname, 'proofs', 'zisk.proof.bin');
     const kbVkPath = path.join(__dirname, 'vks', 'zisk.vk.bin');
 
     console.log('\nLoading eth proof and verification key...');


### PR DESCRIPTION
Both `npm run test:node` and `npm run test` are failing in the `develop` branch.
Here we fix them.